### PR TITLE
fix: use parseUint Cheatcode

### DIFF
--- a/tests/forge/utils/Interop.sol
+++ b/tests/forge/utils/Interop.sol
@@ -19,11 +19,6 @@ contract Interop is Test {
         // so have to do a lil hack to read as string then parse
         // ref https://book.getfoundry.sh/cheatcodes/parse-json#decoding-json-objects-a-tip
         MethodParametersRaw memory raw = abi.decode(vm.parseJson(json, key), (MethodParametersRaw));
-        params = MethodParameters(raw.data, stringToUint(raw.value));
-    }
-
-    function stringToUint(string memory b) private returns (uint256) {
-        vm.setEnv("temp", b);
-        return vm.envUint("temp");
+        params = MethodParameters(raw.data, vm.parseUint(raw.value));
     }
 }


### PR DESCRIPTION
Fixes the issue reported here https://github.com/foundry-rs/foundry/issues/3651

Closes https://github.com/foundry-rs/foundry/issues/3651

Replace the `stringToUint` hack with `parseUint` cheatcode.

`stringToUint` was susceptible to a race condition since all tests run in the same process (shared env vars).

@marktoda 