### PR TITLE
fix: remove instanceof check

### DIFF
--- a/src/swapRouter.ts
+++ b/src/swapRouter.ts
@@ -58,7 +58,7 @@ export abstract class SwapRouter {
 
     const inputCurrency = trade.trade.inputAmount.currency
     invariant(!(inputCurrency.isNative && !!options.inputTokenPermit), 'NATIVE_INPUT_PERMIT')
-    if (options.inputTokenPermit && inputCurrency instanceof Token) {
+    if (options.inputTokenPermit) {
       encodePermit(planner, options.inputTokenPermit)
     }
 


### PR DESCRIPTION
It doesn't work well when used as a dependency, and isn't needed
anyways as we have isNative check above
