### PR TITLE
feat: add build to ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           version: nightly
 
+      - name: build
+        run: yarn build
+
       # needed to generate abi
       - name: Build solidity
         run: forge build


### PR DESCRIPTION
The yarn build commands runs with different strictness than yarn test
apparently, so this commit adds build to CI to ensure anything merged
can be build for production
