### PR TITLE
fix: signature sanitization

### DIFF
--- a/src/utils/permit2.ts
+++ b/src/utils/permit2.ts
@@ -6,15 +6,16 @@ export interface Permit2Permit extends PermitSingle {
   signature: string
 }
 
-const SIGNATURE_LENGTH = 65;
-const EIP_2098_SIGNATURE_LENGTH = 64;
+const SIGNATURE_LENGTH = 65
+const EIP_2098_SIGNATURE_LENGTH = 64
 
 export function encodePermit(planner: RoutePlanner, permit: Permit2Permit): void {
-  let signature = permit.signature;
+  let signature = permit.signature
 
-  const length = ethers.utils.arrayify(permit.signature).length;
+  const length = ethers.utils.arrayify(permit.signature).length
+  // signature data provided for EIP-1271 may have length different from ECDSA signature
   if (length === SIGNATURE_LENGTH || length === EIP_2098_SIGNATURE_LENGTH) {
-    // sanitizes signature to cover edge cases like malformed EIP-2098 sigs and v used as recovery id
+    // sanitizes signature to cover edge cases of malformed EIP-2098 sigs and v used as recovery id
     signature = ethers.utils.joinSignature(ethers.utils.splitSignature(permit.signature))
   }
 

--- a/test/utils/permit2.test.ts
+++ b/test/utils/permit2.test.ts
@@ -12,33 +12,33 @@ const PERMIT_STRUCT =
 
 // note: these tests aren't testing much but registering calldata to interop file
 // for use in forge fork tests
-describe.only('Permit2', () => {
+describe('Permit2', () => {
   const wallet = new Wallet(utils.zeroPad('0x1234', 32))
 
   describe('v2', () => {
-    it('doesnt sanitize a normal permit', async () => {
+    it('does not sanitize a normal permit', async () => {
       const inputUSDC = utils.parseUnits('1000', 6).toString()
       const permit = makePermit(USDC.address, inputUSDC)
       const signature = await generatePermitSignature(permit, wallet, 1)
-      const sanitized = getSanitizedSignature(permit, signature);
-      expect(sanitized).to.equal(signature);
+      const sanitized = getSanitizedSignature(permit, signature)
+      expect(sanitized).to.equal(signature)
     })
 
-    it('doesnt sanitize a triple length permit', async () => {
+    it('does not sanitize a triple length permit', async () => {
       const inputUSDC = utils.parseUnits('1000', 6).toString()
       const permit = makePermit(USDC.address, inputUSDC)
       const signature = await generatePermitSignature(permit, wallet, 1)
-      const multisigSignature = signature + signature.slice(2) + signature.slice(2);
-      const sanitized = getSanitizedSignature(permit, multisigSignature);
-      expect(sanitized).to.equal(multisigSignature);
+      const multisigSignature = signature + signature.slice(2) + signature.slice(2)
+      const sanitized = getSanitizedSignature(permit, multisigSignature)
+      expect(sanitized).to.equal(multisigSignature)
     })
 
-    it('doesnt sanitize a short permit', async () => {
+    it('does not sanitize a short permit', async () => {
       const inputUSDC = utils.parseUnits('1000', 6).toString()
       const permit = makePermit(USDC.address, inputUSDC)
-      const tinySignature = '0x12341234132412341344';
-      const sanitized = getSanitizedSignature(permit, tinySignature);
-      expect(sanitized).to.equal(tinySignature);
+      const tinySignature = '0x12341234132412341344'
+      const sanitized = getSanitizedSignature(permit, tinySignature)
+      expect(sanitized).to.equal(tinySignature)
     })
 
     it('sanitizes a malformed permit', async () => {
@@ -51,15 +51,15 @@ describe.only('Permit2', () => {
       let signature = originalSignature.substring(0, originalSignature.length - 2)
       // append recoveryParam as v
       signature += BigNumber.from(recoveryParam).toHexString().slice(2)
-      const sanitized = getSanitizedSignature(permit, signature);
-      expect(sanitized).to.equal(originalSignature);
+      const sanitized = getSanitizedSignature(permit, signature)
+      expect(sanitized).to.equal(originalSignature)
     })
   })
 
   function getSanitizedSignature(permit: PermitSingle, signature: string): string {
-    const planner = new RoutePlanner();
-    encodePermit(planner, Object.assign({}, permit, { signature: signature }));
+    const planner = new RoutePlanner()
+    encodePermit(planner, Object.assign({}, permit, { signature: signature }))
     const decoded = defaultAbiCoder.decode([PERMIT_STRUCT, 'bytes'], planner.inputs[0])
-    return decoded[1];
+    return decoded[1]
   }
 })


### PR DESCRIPTION
This commit switches to only sanitizing signatures of normal ECDSA
length (64 or 65 bytes). Other signatures may be eip1271 related so we
leave them be
