### PR TITLE
feat: export UNIVERSAL_ROUTER_CREATION_BLOCK

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { SwapRouter } from './swapRouter'
 export * from './entities'
-export { UNIVERSAL_ROUTER_ADDRESS, PERMIT2_ADDRESS, ROUTER_AS_RECIPIENT, WETH_ADDRESS } from './utils/constants'
+export { UNIVERSAL_ROUTER_ADDRESS, UNIVERSAL_ROUTER_CREATION_BLOCK, PERMIT2_ADDRESS, ROUTER_AS_RECIPIENT, WETH_ADDRESS } from './utils/constants'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,9 @@
 export { SwapRouter } from './swapRouter'
 export * from './entities'
-export { UNIVERSAL_ROUTER_ADDRESS, UNIVERSAL_ROUTER_CREATION_BLOCK, PERMIT2_ADDRESS, ROUTER_AS_RECIPIENT, WETH_ADDRESS } from './utils/constants'
+export {
+  UNIVERSAL_ROUTER_ADDRESS,
+  UNIVERSAL_ROUTER_CREATION_BLOCK,
+  PERMIT2_ADDRESS,
+  ROUTER_AS_RECIPIENT,
+  WETH_ADDRESS,
+} from './utils/constants'


### PR DESCRIPTION
https://github.com/Uniswap/universal-router-sdk/pull/129 Added a helper function to get the block height for each chain when UR was added, however to be ingested by downstream dependencies it still needs to be exported.

Unforked https://github.com/Uniswap/universal-router-sdk/pull/137