### PR TITLE
Add creating env file with FORK_URL to "Running this Package" section of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ const { calldata, value } = SwapRouter.swapCallParameters([unwrapWETH, seaportTr
 
 
 ## Running this package
+Create `.env` file with forking url
+
+```
+FORK_URL='xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+```
+
 Make sure you are running `node v16`
 Install dependencies and run typescript unit tests
 ```bash


### PR DESCRIPTION
This adds a missing step to the "Running this Package" part of the Readme.
