### PR TITLE
Update TODO comment with correction

### DIFF
--- a/src/entities/protocols/uniswap.ts
+++ b/src/entities/protocols/uniswap.ts
@@ -47,7 +47,7 @@ export class UniswapTrade implements Command {
 
     // If the input currency is the native currency, we need to wrap it with the router as the recipient
     if (this.trade.inputAmount.currency.isNative) {
-      // TODO: optimize if only one v2 pool we can directly send this to the pool
+      // leave the WETH in the router, as this is cheapest gas-wise than sending it straight to a V2 Pair
       planner.addCommand(CommandType.WRAP_ETH, [
         ROUTER_AS_RECIPIENT,
         this.trade.maximumAmountIn(this.options.slippageTolerance).quotient.toString(),


### PR DESCRIPTION
Did a gas test to check which is cheaper between sending the WETH to the Pair at the time you wrap, or in the V2 payment. Transferring at the time of V2 function is cheapest.

You cannot wrap WETH into a specified recipient address so in either scenario it always has to go

`user -eth-> router -weth-> pair`

the only change is _when_ the weth is sent to the pair, and this is the cheapest.

I think this is because transferring the WETH at the time of wrapping increases the number of non-0 calldata bytes dramatically.