### PR TITLE
chore: bump to 1.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/universal-router-sdk",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "sdk for integrating with the Universal Router contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## Description

- This PR aims to bump the SDK version to 1.7.1
- The ONLY change this version introduces is a **backwards-compatible** `safeMode` introduced #162 