### PR TITLE
chore: update blast UR deploy address and bump to v1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/universal-router-sdk",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "sdk for integrating with the Universal Router contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -100,9 +100,9 @@ const CHAIN_CONFIGS: { [key: number]: ChainConfig } = {
     creationBlock: 9107268,
   },
   [81457]: {
-    router: '0xe463635f6e73C1E595554C3ae216472D0fb929a9',
+    router: '0x643770E279d5D0733F21d6DC03A8efbABf3255B4',
     weth: '0x4300000000000000000000000000000000000004',
-    creationBlock: 401447,
+    creationBlock: 1116444,
   },
 }
 


### PR DESCRIPTION
Unfortunately prior UR doesn't work https://github.com/Uniswap/universal-router-sdk/pull/167. This UR does work, I already verified on simulators:

https://app.sentio.xyz/jsy1218/uniswap/simulator/81457/pwJHhxp7
https://app.sentio.xyz/jsy1218/uniswap/simulator/81457/EH0LxbGN