### PR TITLE
fix: throw on non matching trade types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/universal-router-sdk",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "sdk for integrating with the Universal Router contracts",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/entities/protocols/uniswap.ts
+++ b/src/entities/protocols/uniswap.ts
@@ -198,6 +198,8 @@ function addV2Swap<TInput extends Currency, TOutput extends Currency>(
       route.path.map((pool) => pool.address),
       payerIsUser,
     ])
+  } else {
+    throw new Error('TRADE_TYPE')
   }
 }
 
@@ -234,6 +236,8 @@ function addV3Swap<TInput extends Currency, TOutput extends Currency>(
       path,
       payerIsUser,
     ])
+  } else {
+    throw new Error('TRADE_TYPE')
   }
 }
 
@@ -258,6 +262,10 @@ function addMixedSwap<TInput extends Currency, TOutput extends Currency>(
     } else {
       throw new Error('Invalid route type')
     }
+  }
+
+  if(tradeType !== TradeType.EXACT_INPUT) {
+    throw new Error('TRADE_TYPE')
   }
 
   const trade = MixedRouteTrade.createUncheckedTrade({


### PR DESCRIPTION
If an incorrect trade type is passed into this SDK, it is possible for no calldata to be built at all which is a footgun and should be avoided. This PR throws explicitly on non matching trade types when building uniswap trades.